### PR TITLE
fixed inverted colors

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2426,7 +2426,7 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
 
   // 1-0=11: internal power
   this->data(0x07);
-  this->data(0x07);
+  this->data(0x17);
   this->data(0x3F);
   this->data(0x3F);
 
@@ -2450,7 +2450,7 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
   this->data(0x00);
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
-  this->data(0x11);
+  this->data(0x20);
   this->data(0x07);
   // COMMAND TCON SETTING
   this->command(0x60);


### PR DESCRIPTION
made a quick fix for the inverted colors as I had the same problem while developing and knew which registers to change.

change in line 2429 is based on the datasheet. `VCOM_SLEW` is fixed to at 1
change in line 2453 controls which LUT is used for which color and the border color (disabled again)

Otherwise the image looks fine on my side.

However I am not quite comfortable with applying a higher voltage than necessary (I am not quite sure if this might degrade the display in the long run). Default is 14V and -14V and we are currently applying 15V and -15V. Could you maybe try to delete the line `this->command(0x01);` and the following data lines so we just use the default values? (The default values would work for me as well)